### PR TITLE
T-14442 feat: add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.0
+    hooks:
+      - id: go-fmt
+      - id: go-imports
+      # TODO: re-enable `golangci-lint` and fix all linter errors before re-committing
+      # - id: golangci-lint
+      - id: go-critic
+      - id: go-build
+      - id: go-mod-tidy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.0
+    rev: v0.5.1
     hooks:
       - id: go-fmt
       - id: go-imports

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+init-pre-commit:
+	python3 pre-commit-2.20.0.pyz install;
+	python3 pre-commit-2.20.0.pyz autoupdate;
+	go install golang.org/x/tools/cmd/goimports@latest;
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0;
+	go install -v github.com/go-critic/go-critic/cmd/gocritic@latest;
+	python3 pre-commit-2.20.0.pyz run --all-files;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Relay Meter
 
-The Relay Meter collects relay data from Influx DB, as well as serves it to toehr backend services via a REST API.
+The Relay Meter collects relay data from Influx DB, as well as serves it to other backend services via a REST API.
 
 ## Pre-Commit Installation
 

--- a/README.md
+++ b/README.md
@@ -4,29 +4,7 @@ The Relay Meter collects relay data from Influx DB, as well as serves it to othe
 
 ## Pre-Commit Installation
 
-[Full Instructions here](https://pre-commit.com/#install)
-
-Before you can run the pre-commit hooks, you need to have the **pre-commit** package manager installed.
-
-Using pip:
-
-`pip install pre-commit`
-
-Using homebrew:
-
-`brew install pre-commit`
-
-Then, inside this repo, run the following commands to install **pre-commit** and the required Go packages:
-
-```bash
-pre-commit install;
-pre-commit autoupdate;
-go install golang.org/x/tools/cmd/goimports@latest;
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0;
-go install -v github.com/go-critic/go-critic/cmd/gocritic@latest
-```
-
-Once installed, it's a good idea to run `pre-commit run --all-files` once.
+Run the command `make init-pre-commit` from the repository root.
 
 Once this is done, the following commands will be performed on every commit to the repo and must pass before the commit is allowed:
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# meter
-Metering for performed relays
+# Relay Meter
+
+The Relay Meter collects relay data from Influx DB, as well as serves it to toehr backend services via a REST API.
+
+## Pre-Commit Installation
+
+[Full Instructions here](https://pre-commit.com/#install)
+
+Before you can run the pre-commit hooks, you need to have the **pre-commit** package manager installed.
+
+Using pip:
+
+`pip install pre-commit`
+
+Using homebrew:
+
+`brew install pre-commit`
+
+Then, inside this repo, run the following commands to install **pre-commit** and the required Go packages:
+
+```bash
+pre-commit install;
+pre-commit autoupdate;
+go install golang.org/x/tools/cmd/goimports@latest;
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.49.0;
+go install -v github.com/go-critic/go-critic/cmd/gocritic@latest
+```
+
+Once installed, it's a good idea to run `pre-commit run --all-files` once.
+
+Once this is done, the following commands will be performed on every commit to the repo and must pass before the commit is allowed:
+
+- **go-fmt** - Runs `gofmt`
+- **go-imports** - Runs `goimports`
+- **golangci-lint** - run `golangci-lint run ./...`
+- **go-critic** - run `gocritic check ./...`
+- **go-build** - run `go build`
+- **go-mod-tidy** - run `go mod tidy -v`

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -15,18 +15,18 @@ import (
 
 const (
 	COLLECT_INTERVAL_DEFAULT_SECONDS = 300
-	REPORT_INTERVAL_DEFAULT_SECONDS = 30
-	MAX_ARCHIVE_AGE_DEFAULT_DAYS = 30
+	REPORT_INTERVAL_DEFAULT_SECONDS  = 30
+	MAX_ARCHIVE_AGE_DEFAULT_DAYS     = 30
 
 	ENV_COLLECT_INTERVAL_SECONDS = "COLLECTION_INTERVAL_SECONDS"
-	ENV_REPORT_INTERVAL_SECONDS = "REPORT_INTERVAL_SECONDS"
-	ENV_MAX_ARCHIVE_AGE_DAYS = "MAX_ARCHIVE_AGE"
+	ENV_REPORT_INTERVAL_SECONDS  = "REPORT_INTERVAL_SECONDS"
+	ENV_MAX_ARCHIVE_AGE_DAYS     = "MAX_ARCHIVE_AGE"
 )
 
 type options struct {
 	collectionInterval int
-	reportingInterval int
-	maxArchiveAgeDays int
+	reportingInterval  int
+	maxArchiveAgeDays  int
 }
 
 func gatherOptions() (options, error) {
@@ -45,10 +45,10 @@ func gatherOptions() (options, error) {
 		return options{}, err
 	}
 
-	return options {
+	return options{
 		collectionInterval: collectionInterval,
-		reportingInterval: reportingInterval,
-		maxArchiveAgeDays: maxArchiveAge,
+		reportingInterval:  reportingInterval,
+		maxArchiveAgeDays:  maxArchiveAge,
 	}, nil
 }
 
@@ -71,6 +71,6 @@ func main() {
 	}
 
 	fmt.Printf("Starting the collector...")
-	collector := collector.NewCollector(influxClient, pgClient, time.Duration(options.maxArchiveAgeDays) * 24 * time.Hour, logger.New())
+	collector := collector.NewCollector(influxClient, pgClient, time.Duration(options.maxArchiveAgeDays)*24*time.Hour, logger.New())
 	collector.Start(context.Background(), options.collectionInterval, options.reportingInterval)
 }

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -8,16 +8,16 @@ import (
 )
 
 const (
-	INFLUXDB_URL = "INFLUXDB_URL"
-	INFLUXDB_TOKEN = "INFLUXDB_TOKEN"
-	INFLUXDB_ORG = "INFLUXDB_ORG"
-	INFLUXDB_BUCKET_DAILY = "INFLUXDB_BUCKET_DAILY"
+	INFLUXDB_URL            = "INFLUXDB_URL"
+	INFLUXDB_TOKEN          = "INFLUXDB_TOKEN"
+	INFLUXDB_ORG            = "INFLUXDB_ORG"
+	INFLUXDB_BUCKET_DAILY   = "INFLUXDB_BUCKET_DAILY"
 	INFLUXDB_BUCKET_CURRENT = "INFLUXDB_BUCKET_CURRENT"
 
-	POSTGRES_USER = "POSTGRES_USER"
+	POSTGRES_USER     = "POSTGRES_USER"
 	POSTGRES_PASSWORD = "POSTGRES_PASSWORD"
-	POSTGRES_DB = "POSTGRES_DB"
-	POSTGRES_HOST = "POSTGRES_HOST"
+	POSTGRES_DB       = "POSTGRES_DB"
+	POSTGRES_HOST     = "POSTGRES_HOST"
 )
 
 type options struct {
@@ -26,21 +26,21 @@ type options struct {
 }
 
 func GatherInfluxOptions() db.InfluxDBOptions {
-	return db.InfluxDBOptions {
-		URL: os.Getenv(INFLUXDB_URL),
-		Token: os.Getenv(INFLUXDB_TOKEN),
-		Org: os.Getenv(INFLUXDB_ORG),
-		DailyBucket: os.Getenv(INFLUXDB_BUCKET_DAILY),
+	return db.InfluxDBOptions{
+		URL:           os.Getenv(INFLUXDB_URL),
+		Token:         os.Getenv(INFLUXDB_TOKEN),
+		Org:           os.Getenv(INFLUXDB_ORG),
+		DailyBucket:   os.Getenv(INFLUXDB_BUCKET_DAILY),
 		CurrentBucket: os.Getenv(INFLUXDB_BUCKET_CURRENT),
 	}
 }
 
 func GatherPostgresOptions() db.PostgresOptions {
-	return db.PostgresOptions {
-		User: os.Getenv(POSTGRES_USER),
+	return db.PostgresOptions{
+		User:     os.Getenv(POSTGRES_USER),
 		Password: os.Getenv(POSTGRES_PASSWORD),
-		Host: os.Getenv(POSTGRES_HOST),
-		DB: os.Getenv(POSTGRES_DB),
+		Host:     os.Getenv(POSTGRES_HOST),
+		DB:       os.Getenv(POSTGRES_DB),
 	}
 }
 

--- a/db/influx.go
+++ b/db/influx.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/influxdata/influxdb-client-go/v2"
+	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 
 	"github.com/adshmh/meter/api"
 )

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"database/sql"
+
 	_ "github.com/lib/pq"
 
 	"github.com/adshmh/meter/api"


### PR DESCRIPTION
Before merging, the linter errors for golangci-lint must be fixed. To do so, uncomment golangci-lint in .pre-commit-config.yaml, run pre-commit run --all-files and fix all linter errors before re-committing.

Added pre-commit hooks to lint, format, go mod tidy and more