### PR TITLE
T-14452 Staging updates

### DIFF
--- a/.aws/ecs-task-definition-production.json
+++ b/.aws/ecs-task-definition-production.json
@@ -9,7 +9,7 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-          "awslogs-group": "/ecs/relay-meter",
+          "awslogs-group": "/ecs/relay-meter-collector",
           "awslogs-region": "us-west-2",
           "awslogs-stream-prefix": "ecs"
         }
@@ -57,7 +57,7 @@
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-          "awslogs-group": "/ecs/relay-meter",
+          "awslogs-group": "/ecs/relay-meter-server",
           "awslogs-region": "us-west-2",
           "awslogs-stream-prefix": "ecs"
         }
@@ -110,9 +110,7 @@
   "taskRoleArn": "arn:aws:iam::059424750518:role/ecsTaskExecutionRole",
   "family": "relay-meter",
   "pidMode": null,
-  "requiresCompatibilities": [
-    "FARGATE"
-  ],
+  "requiresCompatibilities": ["FARGATE"],
   "networkMode": "awsvpc",
   "runtimePlatform": {
     "operatingSystemFamily": "LINUX",

--- a/.aws/ecs-task-definition-staging.json
+++ b/.aws/ecs-task-definition-staging.json
@@ -1,0 +1,123 @@
+{
+  "ipcMode": null,
+  "executionRoleArn": "arn:aws:iam::059424750518:role/ecsTaskExecutionRole",
+  "containerDefinitions": [
+    {
+      "dnsSearchDomains": null,
+      "environmentFiles": null,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "secretOptions": null,
+        "options": {
+          "awslogs-group": "/ecs/relay-meter-collector-staging",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "entryPoint": null,
+      "portMappings": [],
+      "command": null,
+      "linuxParameters": null,
+      "cpu": 512,
+      "environment": [],
+      "resourceRequirements": null,
+      "ulimits": null,
+      "dnsServers": null,
+      "mountPoints": [],
+      "workingDirectory": null,
+      "secrets": null,
+      "dockerSecurityOptions": null,
+      "memory": null,
+      "memoryReservation": 1024,
+      "volumesFrom": [],
+      "stopTimeout": null,
+      "image": "059424750518.dkr.ecr.us-west-2.amazonaws.com/relay-meter-collector-staging",
+      "startTimeout": null,
+      "firelensConfiguration": null,
+      "dependsOn": null,
+      "disableNetworking": null,
+      "interactive": null,
+      "healthCheck": null,
+      "essential": true,
+      "links": null,
+      "hostname": null,
+      "extraHosts": null,
+      "pseudoTerminal": null,
+      "user": null,
+      "readonlyRootFilesystem": null,
+      "dockerLabels": null,
+      "systemControls": null,
+      "privileged": null,
+      "name": "relay-meter-collector-staging"
+    },
+    {
+      "dnsSearchDomains": null,
+      "environmentFiles": null,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "secretOptions": null,
+        "options": {
+          "awslogs-group": "/ecs/relay-meter-server-staging",
+          "awslogs-region": "us-west-2",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "entryPoint": null,
+      "portMappings": [
+        {
+          "hostPort": 80,
+          "protocol": "tcp",
+          "containerPort": 80
+        }
+      ],
+      "command": null,
+      "linuxParameters": null,
+      "cpu": 512,
+      "environment": [],
+      "resourceRequirements": null,
+      "ulimits": null,
+      "dnsServers": null,
+      "mountPoints": [],
+      "workingDirectory": null,
+      "secrets": [],
+      "dockerSecurityOptions": null,
+      "memory": null,
+      "memoryReservation": 1024,
+      "volumesFrom": [],
+      "stopTimeout": null,
+      "image": "059424750518.dkr.ecr.us-west-2.amazonaws.com/relay-meter-server-staging",
+      "startTimeout": null,
+      "firelensConfiguration": null,
+      "dependsOn": null,
+      "disableNetworking": null,
+      "interactive": null,
+      "healthCheck": null,
+      "essential": true,
+      "links": null,
+      "hostname": null,
+      "extraHosts": null,
+      "pseudoTerminal": null,
+      "user": null,
+      "readonlyRootFilesystem": null,
+      "dockerLabels": null,
+      "systemControls": null,
+      "privileged": null,
+      "name": "relay-meter-server-staging"
+    }
+  ],
+  "placementConstraints": [],
+  "memory": "2048",
+  "taskRoleArn": "arn:aws:iam::059424750518:role/ecsTaskExecutionRole",
+  "family": "relay-meter-staging",
+  "pidMode": null,
+  "requiresCompatibilities": ["FARGATE"],
+  "networkMode": "awsvpc",
+  "runtimePlatform": {
+    "operatingSystemFamily": "LINUX",
+    "cpuArchitecture": null
+  },
+  "cpu": "1024",
+  "inferenceAccelerators": null,
+  "proxyConfiguration": null,
+  "volumes": []
+}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,22 +1,30 @@
-name: Build and Test
+name: Build & Test
 
 on:
+  pull_request:
+    branches:
+      - main
+      - staging
   push:
-  
-jobs:     
+    branches:
+      - main
+      - staging
+
+jobs:
   test:
-    name: Test
+    name: Build & Run All Tests
     runs-on: ubuntu-latest
+
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.18
 
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Set up cache   
+      - name: Set up cache
         uses: actions/cache@v2
         with:
           path: |
@@ -25,6 +33,9 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
+
+      - name: Build
+        run: go build -v ./...
 
       - name: Run Unit tests
         run: go test ./...

--- a/.github/workflows/staging-us-west-2.yml
+++ b/.github/workflows/staging-us-west-2.yml
@@ -1,9 +1,9 @@
-name: Production deployment us-west-2
+name: Staging deployment us-west-2
 
 on:
   workflow_run:
     workflows: ["Build & Test"]
-    branches: [main]
+    branches: [staging]
     types:
       - completed
 
@@ -31,7 +31,7 @@ jobs:
         id: build-image-collector
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: relay-meter-collector
+          ECR_REPOSITORY: relay-meter-collector-staging
           IMAGE_TAG: latest
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.production.collector .
@@ -42,7 +42,7 @@ jobs:
         id: build-image-api-server
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: relay-meter-server
+          ECR_REPOSITORY: relay-meter-server-staging
           IMAGE_TAG: latest
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.production.apiserver .
@@ -53,8 +53,8 @@ jobs:
         id: task-def-us-west-2-collector
         uses: aws-actions/amazon-ecs-render-task-definition@master
         with:
-          task-definition: .aws/ecs-task-definition-production.json
-          container-name: relay-meter-collector
+          task-definition: .aws/ecs-task-definition-staging.json
+          container-name: relay-meter-collector-staging
           image: ${{ steps.build-image-collector.outputs.image }}
           environment-variables: |
             INFLUXDB_TOKEN=${{ secrets.INFLUXDB_TOKEN }}
@@ -75,7 +75,7 @@ jobs:
         uses: aws-actions/amazon-ecs-render-task-definition@master
         with:
           task-definition: ${{ steps.task-def-us-west-2-collector.outputs.task-definition }}
-          container-name: relay-meter-server
+          container-name: relay-meter-server-staging
           image: ${{ steps.build-image-api-server.outputs.image }}
           environment-variables: |
             API_SERVER_PORT=80
@@ -91,6 +91,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def-us-west-2-server.outputs.task-definition }}
-          service: relay-meter
+          service: relay-meter-staging
           cluster: relay-meter
           wait-for-service-stability: true

--- a/.github/workflows/staging-us-west-2.yml
+++ b/.github/workflows/staging-us-west-2.yml
@@ -57,17 +57,17 @@ jobs:
           container-name: relay-meter-collector-staging
           image: ${{ steps.build-image-collector.outputs.image }}
           environment-variables: |
+            INFLUXDB_URL=${{ secrets.STAGING_INFLUXDB_URL }}
+            POSTGRES_HOST=${{ secrets.STAGING_POSTGRES_HOST }}
+            POSTGRES_PASSWORD=${{ secrets.STAGING_POSTGRES_PASSWORD }}
             INFLUXDB_TOKEN=${{ secrets.INFLUXDB_TOKEN }}
-            INFLUXDB_URL=${{ secrets.INFLUXDB_URL }}
             INFLUXDB_ORG=${{ secrets.INFLUXDB_ORG }}
             INFLUXDB_BUCKET_DAILY=${{ secrets.INFLUXDB_BUCKET_DAILY }}
             INFLUXDB_BUCKET_CURRENT=${{ secrets.INFLUXDB_BUCKET_CURRENT }}
             COLLECTION_INTERVAL_SECONDS=${{ secrets.COLLECTION_INTERVAL_SECONDS }}
             ENV_REPORT_INTERVAL_SECONDS=${{ secrets.ENV_REPORT_INTERVAL_SECONDS }}
-            POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
             POSTGRES_PORT=5432
             POSTGRES_USER=${{ secrets.POSTGRES_USER }}
-            POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
             POSTGRES_DB=${{ secrets.POSTGRES_DB }}
 
       - name: Fill in the new image ID / us-west-2 - server
@@ -78,13 +78,13 @@ jobs:
           container-name: relay-meter-server-staging
           image: ${{ steps.build-image-api-server.outputs.image }}
           environment-variables: |
+            POSTGRES_HOST=${{ secrets.STAGING_POSTGRES_HOST }}
+            POSTGRES_PASSWORD=${{ secrets.STAGING_POSTGRES_PASSWORD }}
+            BACKEND_API_URL=${{ secrets.STAGING_BACKEND_API_URL }}
+            BACKEND_API_TOKEN=${{ secrets.STAGING_BACKEND_API_TOKEN }}
             API_SERVER_PORT=80
-            BACKEND_API_URL=${{ secrets.BACKEND_API_URL }}
-            BACKEND_API_TOKEN=${{ secrets.BACKEND_API_TOKEN }}
-            POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
             POSTGRES_PORT=5432
             POSTGRES_USER=${{ secrets.POSTGRES_USER }}
-            POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
             POSTGRES_DB=${{ secrets.POSTGRES_DB }}
 
       - name: Deploy / us-west-2


### PR DESCRIPTION
Do not merge until post-pokemon go live.

This PR adds all deploy files for creating a staging instance of PUB.

ECR and Cloudwatch log groups will need to be created in AWS before merging this.

The following secrets need to be set as well:
`STAGING_INFLUXDB_URL`
`STAGING_POSTGRES_HOST`
`STAGING_POSTGRES_PASSWORD`
`STAGING_BACKEND_API_URL`
`STAGING_BACKEND_API_TOKEN`