### PR TITLE
T-17525 feat: add authorization to relay meter

### DIFF
--- a/.github/workflows/production-us-west-2.yml
+++ b/.github/workflows/production-us-west-2.yml
@@ -88,6 +88,7 @@ jobs:
             POSTGRES_USER=${{ secrets.POSTGRES_USER }}
             POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
             POSTGRES_DB=${{ secrets.POSTGRES_DB }}
+            API_KEYS=${{ secrets.API_KEYS }}
 
       - name: Fill in the new image ID / us-west-2 (Datadog Agent)
         id: task-def-us-west-2-datadog-agent

--- a/api/server.go
+++ b/api/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	logger "github.com/sirupsen/logrus"
@@ -19,16 +20,16 @@ const (
 
 var (
 	// TODO: should we limit the length of application public key or user id in the path regexp?
-	appsRelaysPath          = regexp.MustCompile(`^/v0/relays/apps/([[:alnum:]]+)$`)
-	allAppsRelaysPath       = regexp.MustCompile(`^/v0/relays/apps`)
-	usersRelaysPath         = regexp.MustCompile(`^/v0/relays/users/([[:alnum:]]+)$`)
-	lbRelaysPath            = regexp.MustCompile(`^/v0/relays/endpoints/([[:alnum:]]+)$`)
-	allLbsRelaysPath        = regexp.MustCompile(`^/v0/relays/endpoints`)
-	totalRelaysPath         = regexp.MustCompile(`^/v0/relays`)
-	originUsagePath         = regexp.MustCompile(`^/v0/relays/origin-classification`)
-	specificOriginUsagePath = regexp.MustCompile(`^/v0/relays/origin-classification/([[:alnum:]].*)`)
-	appsLatencyPath         = regexp.MustCompile(`^/v0/latency/apps/([[:alnum:]]+)$`)
-	allAppsLatencyPath      = regexp.MustCompile(`^/v0/latency/apps`)
+	appsRelaysPath          = regexp.MustCompile(`^/v[0-1]/relays/apps/([[:alnum:]]+)$`)
+	allAppsRelaysPath       = regexp.MustCompile(`^/v[0-1]/relays/apps`)
+	usersRelaysPath         = regexp.MustCompile(`^/v[0-1]/relays/users/([[:alnum:]]+)$`)
+	lbRelaysPath            = regexp.MustCompile(`^/v[0-1]/relays/endpoints/([[:alnum:]]+)$`)
+	allLbsRelaysPath        = regexp.MustCompile(`^/v[0-1]/relays/endpoints`)
+	totalRelaysPath         = regexp.MustCompile(`^/v[0-1]/relays`)
+	originUsagePath         = regexp.MustCompile(`^/v[0-1]/relays/origin-classification`)
+	specificOriginUsagePath = regexp.MustCompile(`^/v[0-1]/relays/origin-classification/([[:alnum:]].*)`)
+	appsLatencyPath         = regexp.MustCompile(`^/v[0-1]/latency/apps/([[:alnum:]]+)$`)
+	allAppsLatencyPath      = regexp.MustCompile(`^/v[0-1]/latency/apps`)
 )
 
 // TODO: move these custom error codes to the api package
@@ -204,14 +205,16 @@ func GetHttpServer(meter RelayMeter, l *logger.Logger, apiKeys map[string]bool) 
 	return func(w http.ResponseWriter, req *http.Request) {
 		log := l.WithFields(logger.Fields{"Request": *req})
 
-		if !apiKeys[req.Header.Get("Authorization")] {
-			w.WriteHeader(http.StatusUnauthorized)
-			_, err := w.Write([]byte("Unauthorized"))
-			if err != nil {
-				log.Error("Write in Unauthorized request failed")
-			}
+		if strings.HasPrefix(req.URL.Path, "/v1") {
+			if !apiKeys[req.Header.Get("Authorization")] {
+				w.WriteHeader(http.StatusUnauthorized)
+				_, err := w.Write([]byte("Unauthorized"))
+				if err != nil {
+					log.Error("Write in Unauthorized request failed")
+				}
 
-			return
+				return
+			}
 		}
 
 		if req.Method != http.MethodGet {

--- a/api/server.go
+++ b/api/server.go
@@ -205,16 +205,14 @@ func GetHttpServer(meter RelayMeter, l *logger.Logger, apiKeys map[string]bool) 
 	return func(w http.ResponseWriter, req *http.Request) {
 		log := l.WithFields(logger.Fields{"Request": *req})
 
-		if strings.HasPrefix(req.URL.Path, "/v1") {
-			if !apiKeys[req.Header.Get("Authorization")] {
-				w.WriteHeader(http.StatusUnauthorized)
-				_, err := w.Write([]byte("Unauthorized"))
-				if err != nil {
-					log.Error("Write in Unauthorized request failed")
-				}
-
-				return
+		if strings.HasPrefix(req.URL.Path, "/v1") && !apiKeys[req.Header.Get("Authorization")] {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, err := w.Write([]byte("Unauthorized"))
+			if err != nil {
+				log.Error("Write in Unauthorized request failed")
 			}
+
+			return
 		}
 
 		if req.Method != http.MethodGet {

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -79,7 +79,7 @@ func TestGetHttpServer(t *testing.T) {
 		},
 		{
 			name: "Failed auhtorization",
-			url: fmt.Sprintf("http://relay-meter.pokt.network/v0/relays/endpoints?from=%s&to=%s",
+			url: fmt.Sprintf("http://relay-meter.pokt.network/v1/relays/endpoints?from=%s&to=%s",
 				url.QueryEscape(now.Format(time.RFC3339)),
 				url.QueryEscape(now.Format(time.RFC3339)),
 			),

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -22,6 +22,7 @@ func TestGetHttpServer(t *testing.T) {
 		url                string
 		expected           string
 		expectedStatusCode int
+		failAuth           bool
 	}{
 		{
 			name: "App relays path is handled correctly",
@@ -76,13 +77,25 @@ func TestGetHttpServer(t *testing.T) {
 			),
 			expectedStatusCode: http.StatusOK,
 		},
+		{
+			name: "Failed auhtorization",
+			url: fmt.Sprintf("http://relay-meter.pokt.network/v0/relays/endpoints?from=%s&to=%s",
+				url.QueryEscape(now.Format(time.RFC3339)),
+				url.QueryEscape(now.Format(time.RFC3339)),
+			),
+			failAuth:           true,
+			expectedStatusCode: http.StatusUnauthorized,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			httpServer := GetHttpServer(&fakeRelayMeter{}, logger.New())
+			httpServer := GetHttpServer(&fakeRelayMeter{}, logger.New(), map[string]bool{"dummy": true})
 
 			req := httptest.NewRequest("GET", tc.url, nil)
+			if !tc.failAuth {
+				req.Header.Add("Authorization", "dummy")
+			}
 			w := httptest.NewRecorder()
 
 			httpServer(w, req)
@@ -93,10 +106,12 @@ func TestGetHttpServer(t *testing.T) {
 				t.Errorf("Expected status code: %d, got: %d", tc.expectedStatusCode, resp.StatusCode)
 			}
 
-			body, _ := io.ReadAll(resp.Body)
-			var r AppRelaysResponse
-			if err := json.Unmarshal(body, &r); err != nil {
-				t.Fatalf("Unexpected error unmarhsalling the response: %v", err)
+			if !tc.failAuth {
+				body, _ := io.ReadAll(resp.Body)
+				var r AppRelaysResponse
+				if err := json.Unmarshal(body, &r); err != nil {
+					t.Fatalf("Unexpected error unmarhsalling the response: %v", err)
+				}
 			}
 		})
 	}

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -57,7 +57,7 @@ func gatherOptions() options {
 		todaysMetricsTTLSeconds: int(environment.GetInt64(ENV_TODAYS_METRICS_TTL_SECONDS, TODAYS_METRICS_TTL_DEFAULT_SECONDS)),
 		maxPastDays:             int(environment.GetInt64(ENV_MAX_ARCHIVE_AGE_DAYS, MAX_ARCHIVE_AGE_DEFAULT_DAYS)),
 		port:                    int(environment.GetInt64(ENV_SERVER_PORT, SERVER_PORT_DEFAULT)),
-		apiKeys:                 environment.MustGetStringMap("API_KEYS", ","),
+		apiKeys:                 environment.MustGetStringMap("API_KEYS", ";"),
 	}
 }
 

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -45,6 +45,7 @@ type options struct {
 	todaysMetricsTTLSeconds int
 	maxPastDays             int
 	port                    int
+	apiKeys                 map[string]bool
 }
 
 func gatherOptions() options {
@@ -56,6 +57,7 @@ func gatherOptions() options {
 		todaysMetricsTTLSeconds: int(environment.GetInt64(ENV_TODAYS_METRICS_TTL_SECONDS, TODAYS_METRICS_TTL_DEFAULT_SECONDS)),
 		maxPastDays:             int(environment.GetInt64(ENV_MAX_ARCHIVE_AGE_DAYS, MAX_ARCHIVE_AGE_DEFAULT_DAYS)),
 		port:                    int(environment.GetInt64(ENV_SERVER_PORT, SERVER_PORT_DEFAULT)),
+		apiKeys:                 environment.MustGetStringMap("API_KEYS", ","),
 	}
 }
 
@@ -188,7 +190,7 @@ func main() {
 		backendApiToken: options.backendApiToken,
 	}
 	meter := api.NewRelayMeter(&backend, log, meterOptions)
-	http.HandleFunc("/", api.GetHttpServer(meter, log))
+	http.HandleFunc("/", api.GetHttpServer(meter, log, options.apiKeys))
 
 	log.Info("Starting the apiserver...")
 	http.ListenAndServe(fmt.Sprintf(":%d", options.port), nil)


### PR DESCRIPTION
Adds simple authorization as used in other repos to relay meter

To not break all integrations will just be added for v1 endpoints until all clients are updated